### PR TITLE
Get last electricity and gas submissions separately

### DIFF
--- a/internal/octopus/octopus.go
+++ b/internal/octopus/octopus.go
@@ -75,7 +75,7 @@ func get(ctx context.Context, client *octopusenergy.Client, opts octopusenergy.C
 	return nil
 }
 
-func GetConsumption(wg *sync.WaitGroup, config *conf.Conf, grp *errgroup.Group, ctx context.Context, period *time.Time, c chan<- *ConsumptionResponse) {
+func GetConsumption(wg *sync.WaitGroup, config *conf.Conf, grp *errgroup.Group, ctx context.Context, electricityPeriod *time.Time, gasPeriod *time.Time, c chan<- *ConsumptionResponse) {
 	log.Debug("Creating octopus client")
 	var netClient = http.Client{
 		Timeout: time.Second * 10,
@@ -87,7 +87,7 @@ func GetConsumption(wg *sync.WaitGroup, config *conf.Conf, grp *errgroup.Group, 
 
 	var orderByPeriod = "period"
 
-	log.Debugf("Getting consumption since %s", period)
+	log.Debugf("Getting consumption since %s (electricity), %s (gas)", electricityPeriod, gasPeriod)
 	if config.ElectricityMPN != "" {
 		wg.Add(1)
 	}
@@ -102,7 +102,7 @@ func GetConsumption(wg *sync.WaitGroup, config *conf.Conf, grp *errgroup.Group, 
 				MPN:          config.ElectricityMPN,
 				SerialNumber: config.ElectricitySerial,
 				FuelType:     octopusenergy.FuelTypeElectricity,
-				PeriodFrom:   period,
+				PeriodFrom:   electricityPeriod,
 				OrderBy:      &orderByPeriod,
 			}
 			return get(ctx, client, opts, c)
@@ -116,7 +116,7 @@ func GetConsumption(wg *sync.WaitGroup, config *conf.Conf, grp *errgroup.Group, 
 				MPN:          config.GasMPN,
 				SerialNumber: config.GasSerial,
 				FuelType:     octopusenergy.FuelTypeGas,
-				PeriodFrom:   period,
+				PeriodFrom:   gasPeriod,
 				OrderBy:      &orderByPeriod,
 			}
 			return get(ctx, client, opts, c)


### PR DESCRIPTION
It might be the case that they get returned over the API at different
times. Imagine if we get gas up to 23:00 yesterday, but electricity up
to 21:30. We'll currently submit the gas reading, and then subsequent
runs will query both from 23:00 onwards. The electricity data from
21:30 -> 23:00 will be lost.

Instead, query for each last submission separately, and then request
that returned time for the respective fuel type from the Octopus API.